### PR TITLE
Added priorities to Events and Series

### DIFF
--- a/api/controllers/calendar.js
+++ b/api/controllers/calendar.js
@@ -20,6 +20,7 @@ function buildCalendar(req, res, timezone) {
 		db.Event.findAll({
 			include: [
 				{ model: db.Track },
+				{ model: db.Series},
 				{
 					model: db.EventSession,
 					include: [
@@ -28,6 +29,7 @@ function buildCalendar(req, res, timezone) {
 				}
 			],
 			order: [
+				['priority', 'ASC'],
 				['startdate', 'ASC'],
 				[db.EventSession, 'starttime', 'ASC']
 			]

--- a/api/models/Event.js
+++ b/api/models/Event.js
@@ -6,7 +6,11 @@ module.exports = (sequelize, DataTypes) => {
 			primaryKey: true
 		},
 		name: DataTypes.STRING,
-		logo: DataTypes.STRING,
+		priority: DataTypes.INTEGER,
+		logo: {
+			type: DataTypes.STRING,
+			defaultValue: ''
+		},
 		startdate: DataTypes.DATEONLY,
 		enddate: DataTypes.DATEONLY,
 		timezone: DataTypes.STRING,
@@ -25,6 +29,7 @@ module.exports = (sequelize, DataTypes) => {
 
 	Event.associate = models => {
 		models.Event.belongsTo(models.Track, {foreignKey: 'track'});
+		models.Event.belongsTo(models.Series, {foreignKey: 'mainseries'});
 		models.Event.hasMany(models.EventSession, {foreignKey: 'event'});
 	};
 

--- a/api/models/Series.js
+++ b/api/models/Series.js
@@ -8,6 +8,7 @@ module.exports = (sequelize, DataTypes) => {
 		name: DataTypes.STRING,
 		logo: DataTypes.STRING,
 		homepage: DataTypes.STRING,
+		priority: DataTypes.INTEGER,
 		createdAt: {
 			type: DataTypes.DATE,
 			defaultValue: sequelize.fn('NOW')
@@ -23,6 +24,7 @@ module.exports = (sequelize, DataTypes) => {
 
 	Series.associate = models => {
 		models.Series.hasMany(models.EventSession, {foreignKey: 'series'});
+		models.Series.hasMany(models.Event, {foreignKey: 'mainseries'});
 	};
 
 	return Series;

--- a/components/calendar/Event.vue
+++ b/components/calendar/Event.vue
@@ -7,17 +7,18 @@
 				<div class="md-subhead">{{ event.Track.name }}</div>
 				<div class="md-subhead">{{ startdate }} - {{ enddate }}<br />
 					({{ event.timezone }}, UTC{{ offset }})</div>
+				<div class="md-subhead">Priority: {{ event.priority }}</div>
 			</md-card-header-text>
 
 			<md-card-media>
-				<img :src="event.logo" alt="Logo">
+				<img :src="eventLogo" alt="Logo">
 			</md-card-media>
 		</md-card-header>
-		<!--<md-card-content>
+		<!-- <md-card-content>
 
-		</md-card-content>-->
+		</md-card-content> -->
 		<md-card-actions>
-			<md-button @click.native='showSessions()'>Show sessions</md-button>
+			<md-button @click.native='toggleSessions()'>Show sessions</md-button>
 		</md-card-actions>
 	</md-card>
 </div>
@@ -48,13 +49,16 @@ export default {
 		enddate: function() {
 			return moment(this.event.enddate).format('ddd Do MMM YYYY');
 		},
+		eventLogo: function() {
+			return this.event.logo.length > 1 ? this.event.logo : this.event.Series.logo;
+		},
 		offset: function() {
 			return moment.tz(this.event.timezone).format('Z');
 		}
 	},
 	methods: {
-		showSessions: function() {
-			this.$emit('showSessions', this.event);
+		toggleSessions: function() {
+			this.$emit('toggleSessions', this.event);
 		}
 	}
 };

--- a/components/calendar/FilterPanel.vue
+++ b/components/calendar/FilterPanel.vue
@@ -1,13 +1,29 @@
 <template>
 <div class="md-layout-item md-size-20 filter">
 	<div>FILTER-BOX</div>
+	<md-button class="md-raised md-primary" @click.native='toggleCurrentEvents()'>{{ showCurrentEventsLabel }}</md-button>
 </div>
 </template>
 
 <script>
 
 export default {
-
+	props: {
+		showCurrentEvents: {
+			type: Boolean,
+			default: true
+		}
+	},
+	computed: {
+		showCurrentEventsLabel: function() {
+			return this.showCurrentEvents ? 'Show all' : 'Show current';
+		}
+	},
+	methods: {
+		toggleCurrentEvents: function() {
+			this.$emit('toggleCurrentEvents');
+		}
+	}
 };
 </script>
 

--- a/components/calendar/SidePanel.vue
+++ b/components/calendar/SidePanel.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="md-layout-item md-size-20 sidepanel">
 	<div v-if="showEvent" class="sessions">
-		<md-icon class="md-size-2x" @click.native='hideSessions()'>arrow_back</md-icon>
+		<md-icon class="md-size-2x" @click.native='toggleSessions()'>arrow_back</md-icon>
 		<br />
 		<br />
 		<EventSession
@@ -37,8 +37,8 @@ export default {
 		}
 	},
 	methods: {
-		hideSessions: function() {
-			this.$emit('hideSessions');
+		toggleSessions: function() {
+			this.$emit('toggleSessions', null);
 		}
 	}
 };

--- a/database/testdata.sql
+++ b/database/testdata.sql
@@ -1,27 +1,41 @@
 INSERT INTO Usertype (id, name) VALUES (1, 'Admin');
 INSERT INTO Usertype (id, name) VALUES (2, 'TV Crew');
 
+# Password is 'admin'
 INSERT INTO User (username, password, name, usertype) VALUES ('admin', '$2a$08$PpEU2iK0atLmAkcKjXPXD.byYaw3Fxzlen3VUxB8l70U.IQkb/yZ.', 'Admin', 1);
 
 INSERT INTO Track (id, name, location, length, map) VALUES (1, "Nordschleife", "Nürburg", 20.832, "");
 INSERT INTO Track (id, name, location, length, map) VALUES (2, "Mount Panorama Circuit", "Bathurst", 6.213, "");
 INSERT INTO Track (id, name, location, length, map) VALUES (3, "Circuit de Spa-Francorchamps", "Spa-Francorchamps", 7.004, "");
+INSERT INTO Track (id, name, location, length, map) VALUES (4, "Daytona International Speedway", "Daytona", 5.73, "");
+INSERT INTO Track (id, name, location, length, map) VALUES (5, "Road America", "Elkhart Lake", 6.515, "");
+INSERT INTO Track (id, name, location, length, map) VALUES (6, "Surfers Paradise Street Circuit", "Surfers Paradise", 2.98, "");
 
-INSERT INTO Series (id, name) VALUES (1, "VLN");
-INSERT INTO Series (id, name) VALUES (2, "Intercontinental GT Challenge");
-INSERT INTO Series (id, name) VALUES (3, "Blancpain Endurance Cup");
-INSERT INTO Series (id, name) VALUES (4, "GT2");
+INSERT INTO Series (id, name, priority, logo) VALUES (1, "VLN", 1, "https://kappelermotorsport.files.wordpress.com/2015/08/logovln.gif");
+INSERT INTO Series (id, name, priority) VALUES (2, "Intercontinental GT Challenge", 2);
+INSERT INTO Series (id, name, priority) VALUES (3, "Blancpain Endurance Cup", 2);
+INSERT INTO Series (id, name, priority) VALUES (4, "GT2", 2);
+INSERT INTO Series (id, name, priority, logo) VALUES (5, "IMSA WeatherTech SportsCar Championship", 1, "https://upload.wikimedia.org/wikipedia/en/thumb/2/28/WeatherTech_SportsCar_Championship_logo.png/300px-WeatherTech_SportsCar_Championship_logo.png");
+INSERT INTO Series (id, name, priority, logo) VALUES (6, "Virgin Australia Supercars Championship", 3, "https://upload.wikimedia.org/wikipedia/en/thumb/d/dd/Supercars_Championship_logo.svg/1200px-Supercars_Championship_logo.svg.png");
 
-INSERT INTO Event (id, name, logo, startdate, enddate, timezone, track) VALUES (1, "Bathurst 12 Hour", "https://da2.rbmbtnx.net/v4/RBTV/pd/FO-1Y9A5DRAW5N11/im:i:q_70,f_png,e_trim/im:i:w_600,c_limit/a:s/st:iAJvI63Os4zYB9_BGlY7jW/bathurst12hour_titletreatment_squarelogo.svg", "2019-02-01", "2019-02-03", 'Australia/Sydney', 2);
-INSERT INTO Event (id, name, logo, startdate, enddate, timezone, track) VALUES (2, "Nürburgring 24 Hours", "https://reifenpresse.de/wp-content/uploads/2018/11/ADAC-neuer-24h-Titelsponsor.jpg", "2019-06-20", "2019-06-23", 'Europe/Brussels', 1);
-INSERT INTO Event (id, name, logo, startdate, enddate, timezone, track) VALUES (3, "Spa 24 Hours", "https://tickets-2-u.com/wp-content/uploads/2018/05/24Hours_Spa.png", "2019-07-26", "2019-07-28", 'Europe/Brussels', 3);
+INSERT INTO Event (id, name, logo, startdate, enddate, timezone, track, priority, mainseries) VALUES (1, "Bathurst 12 Hour", "https://da2.rbmbtnx.net/v4/RBTV/pd/FO-1Y9A5DRAW5N11/im:i:q_70,f_png,e_trim/im:i:w_600,c_limit/a:s/st:iAJvI63Os4zYB9_BGlY7jW/bathurst12hour_titletreatment_squarelogo.svg", "2019-02-01", "2019-02-03", 'Australia/Sydney', 2, 2, 2);
+INSERT INTO Event (id, name, logo, startdate, enddate, timezone, track, priority, mainseries) VALUES (2, "Nürburgring 24 Hours", "https://reifenpresse.de/wp-content/uploads/2018/11/ADAC-neuer-24h-Titelsponsor.jpg","2019-06-20", "2019-06-23", 'Europe/Brussels', 1, 1, 1);
+INSERT INTO Event (id, name, logo, startdate, enddate, timezone, track, priority, mainseries) VALUES (3, "Spa 24 Hours", "https://tickets-2-u.com/wp-content/uploads/2018/05/24Hours_Spa.png", "2019-07-26", "2019-07-28", 'Europe/Brussels', 3, 2, 3);
+INSERT INTO Event (id, name, startdate, enddate, timezone, track, priority, mainseries) VALUES (4, "Bathurst 1000", "2019-10-13", "2019-10-13", "Australia/Sydney", 2, 3, 6);
+INSERT INTO Event (id, name, startdate, enddate, timezone, track, priority, mainseries) VALUES (5, "Gold Coast 600", "2019-10-26", "2019-10-27","Australia/Brisbane", 6, 3, 6);
+INSERT INTO Event (id, name, startdate, enddate, timezone, track, priority, mainseries) VALUES (6, "Road Race Showcase at Road America", "2019-08-03", "2019-08-04", "America/Chicago", 5, 2, 5);
+INSERT INTO Event (id, name, startdate, enddate, timezone, track, priority, mainseries) VALUES (7, "24 Hours of Daytona", "2020-01-24", "2020-01-26", "America/New_York", 4, 1, 5);
+INSERT INTO Event (id, name, startdate, enddate, timezone, track, priority, mainseries) VALUES (8, "51. ADAC Barbarossapreis (VLN 8)", "2019-10-13", "2019-10-13", "Europe/Brussels", 1, 2, 1);
 
+# Bathurst 12 Hours
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Top 10 Shootout", "2019-02-02 06:30", "2019-02-02 07:15", 1, 2);
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Race", "2019-02-02 19:45", "2019-02-03 07:45", 1, 2);
 
+# N24
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Qualifying", "2019-06-21 14:00", "2019-06-21 16:00", 2, 1);
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Race", "2019-06-22 15:00", "2019-06-23 15:00", 2, 1);
 
+# Spa 24
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Top 3 GT2 shootout", "2019-07-26 14:00", "2019-07-26 15:00", 3, 4);
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Inaugural GT2 race", "2019-07-26 18:00", "2019-07-26 19:00", 3, 4);
 INSERT INTO EventSession (name, starttime, endtime, event, series) VALUES ("Top 30 Qualifying", "2019-07-27 10:00", "2019-07-27 11:00", 3, 3);

--- a/pages/calendar/index.vue
+++ b/pages/calendar/index.vue
@@ -1,23 +1,31 @@
 <template>
 <div class="md-layout">
-	<FilterPanel />
+	<FilterPanel
+		:show-current-events="showCurrentEvents"
+		@toggleCurrentEvents="toggleCurrentEvents"
+	/>
 
-	<div class="md-layout md-layout-item flex-start">
-		<Event
-			v-for="event in data.events"
-			:key="event.id"
-			:event="event"
-			:tz="data.tz"
-			:active-event="activeEvent"
-			@showSessions="showSessions"
-		/>
+	<div class="md-layout-item flex-start">
+		<div class="headline">
+			<span class="md-display-1">{{ headline }}</span><br />
+		</div>
+		<div class="md-layout">
+			<Event
+				v-for="event in filterEvents()"
+				:key="event.id"
+				:event="event"
+				:tz="data.tz"
+				:active-event="activeEvent"
+				@toggleSessions="toggleSessions"
+			/>
+		</div>
 	</div>
 
 	<SidePanel
 		:event="activeEvent"
 		:show-event="showEvent"
 		:tz="data.tz"
-		@hideSessions="hideSessions"
+		@toggleSessions="toggleSessions"
 	/>
 </div>
 </template>
@@ -26,6 +34,8 @@
 import Event from '~/components/calendar/Event.vue';
 import FilterPanel from '~/components/calendar/FilterPanel.vue';
 import SidePanel from '~/components/calendar/SidePanel.vue';
+
+import moment from 'moment-timezone';
 
 export default {
 	components: {
@@ -36,9 +46,15 @@ export default {
 	data: function() {
 		return {
 			data: [],
+			showCurrentEvents: true,
 			activeEvent: null,
 			showEvent: false
 		};
+	},
+	computed: {
+		headline: function() {
+			return this.showCurrentEvents ? 'This week\'s events' : 'All events';
+		}
 	},
 	async asyncData({
 		$axios
@@ -49,13 +65,25 @@ export default {
 		};
 	},
 	methods: {
-		showSessions: function(event) {
-			this.showEvent = true;
-			this.activeEvent = event;
+		toggleSessions: function(event) {
+			if (!this.showEvent) {
+				this.showEvent = true;
+				this.activeEvent = event;
+			} else {
+				this.showEvent = false;
+				this.activeEvent = null;
+			}
 		},
-		hideSessions: function() {
-			this.showEvent = false;
-			this.activeEvent = null;
+		toggleCurrentEvents: function() {
+			this.showCurrentEvents = !this.showCurrentEvents;
+		},
+		filterEvents: function() {
+			if (this.showCurrentEvents)
+				return this.data.events.filter(function(event) {
+					return moment(event.startdate).isBefore('2019-07-01');
+				});
+			else
+				return this.data.events;
 		}
 	}
 };
@@ -64,5 +92,8 @@ export default {
 <style lang="scss" scoped>
 .flex-start {
 	align-content: flex-start;
+}
+.headline {
+	padding: 1em;
 }
 </style>


### PR DESCRIPTION
I added priorities to Events and Series. The events on the canlendar page are now sorted by priority first and then by date.

The calendar shows only the current week's events by default, but all other events can be made visible.