### PR TITLE
Let user set local timezone

### DIFF
--- a/components/calendar/EventSession.vue
+++ b/components/calendar/EventSession.vue
@@ -1,11 +1,11 @@
 <template>
 <p>
-	<strong>{{ session.name }}</strong> ({{ session.Series.name }}) {{ starttime }}
+	<strong>{{ session.name }}</strong> ({{ session.Series.name }}) Local time: {{ getLocalTime() }}, User time: {{ getUserTime() }}
 </p>
 </template>
 
 <script>
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 export default {
 	props: {
@@ -13,14 +13,26 @@ export default {
 			type: Object,
 			default: null
 		},
-		tz: {
-			type: Object,
-			default: null
+		localTimezone : {
+			type: String,
+			default: ''
+		},
+		userTimezone: {
+			type: String,
+			default: ''
 		}
 	},
-	computed: {
-		starttime: function() {
-			return moment(this.session.starttime).format('ddd Do MMM HH:mm')+'h';
+	methods: {
+		getLocalTime: function() {
+			return moment(this.session.starttime).tz(this.localTimezone).format('ddd Do MMM HH:mm')+'h';
+		},
+		getUserTime: function() {
+			let local_tz;
+			if (this.userTimezone === undefined || moment.tz.zone(this.userTimezone.name) === null)
+				local_tz = 'Europe/Brussels';
+			else
+				local_tz = this.userTimezone.name;
+			return moment(this.session.starttime).tz(local_tz).format('ddd Do MMM HH:mm')+'h';
 		}
 	}
 };

--- a/components/calendar/SidePanel.vue
+++ b/components/calendar/SidePanel.vue
@@ -10,7 +10,8 @@
 			v-for="session in event.EventSessions"
 			:key="session.id"
 			:session="session"
-			:tz="tz"
+			:local-timezone="event.Track.timezone"
+			:user-timezone="userTimezone"
 		/>
 	</div>
 </div>
@@ -32,9 +33,9 @@ export default {
 			type: Boolean,
 			default: false
 		},
-		tz: {
-			type: Object,
-			default: null
+		userTimezone: {
+			type: String,
+			default: ''
 		}
 	},
 	methods: {

--- a/components/resources/CRUD-EventSession.vue
+++ b/components/resources/CRUD-EventSession.vue
@@ -12,7 +12,7 @@
 				<div class="md-list-item-text">
 					<div class="md-layout">
 						<div class="md-layout-item">
-							<strong>{{ es.name }} ({{ es.Series.name }})</strong> {{ es.starttime }}
+							<strong>{{ es.name }} ({{ es.Series.name }})</strong> {{ getLocalTime(es) }}
 						</div>
 						<div class="md-layout-item">
 							<md-icon class="" @click.native="deleteSession(es.id)">
@@ -262,6 +262,10 @@ export default {
 				arr.push(series.Series);
 			});
 			return arr;
+		},
+		getLocalTime: function(session) {
+			let local_tz = this.event.Track.timezone;
+			return moment(session.starttime).tz(local_tz).format();
 		},
 		validInput: function() {
 			return this.eventsession.name.length > 0 &&

--- a/pages/calendar/index.vue
+++ b/pages/calendar/index.vue
@@ -73,6 +73,15 @@ export default {
 			return this.showCurrentEvents ? 'This week\'s events' : 'All events';
 		}
 	},
+	watch: {
+		userTimezone: function(newValue) {
+			// save new local timezone in cookie
+			if (moment.tz.zone(newValue.name) !== null) {
+				let cookieDate = new Date(moment().add(12, 'months').toDate());
+				document.cookie = 'localtz=' + newValue.name + '; expires ' + cookieDate;
+			}
+		}
+	},
 	async asyncData({
 		$axios
 	}) {
@@ -94,18 +103,19 @@ export default {
 				this.activeEvent = null;
 			}
 		});
-		// Set the initial timezone
+		// Set the initial timezone, load from cookie if possible
 		let tz_name = 'Europe/Brussels';
+		if (document.cookie.split(';').filter((item) => item.trim().startsWith('localtz=')).length) {
+			tz_name = document.cookie.replace(/(?:(?:^|.*;\s*)localtz\s*=\s*([^;]*).*$)|^.*$/, '$1');
+		}
 		let tz_desc = this.data.tz.tz_strings[tz_name];
 		this.userTimezone = {
 			'name':tz_name,
-			'desc': tz_desc,
+			'desc':tz_desc,
 			'toLowerCase':()=>tz_desc.toLowerCase(),
 			// 'toString':()=>'(UTC' + moment.tz(tz_name).format('Z') + ') ' + tz_desc
 			'toString':()=>tz_desc
-
 		};
-
 	},
 	methods: {
 		filterEvents: function() {

--- a/pages/calendar/index.vue
+++ b/pages/calendar/index.vue
@@ -8,6 +8,27 @@
 		<div class="headline">
 			<span class="md-display-1">{{ headline }}</span><br />
 		</div>
+		<md-autocomplete v-model="userTimezone" md-dense :md-options="data.tz.tz_array.map(x=>({
+			'name':x.name,
+			'desc': x.desc,
+			'toLowerCase':()=>x.desc.toLowerCase(),
+			'toString':()=>x.desc
+		}))"
+		>
+			<label>Local Timezone</label>
+
+			<template slot="md-autocomplete-item" slot-scope="{ item }">
+				<!-- <span class="color" :style="`background-color: ${item.color}`"></span> -->
+				<!-- <md-highlight-text :md-term="tzDisplay(item)">{{ tzDisplay(item) }}</md-highlight-text> -->
+				{{ tzDisplay(item) }}
+			</template>
+
+			<template slot="md-autocomplete-empty" slot-scope="{ term }">
+				"{{ term }}" not found!
+			</template>
+
+			<span class="md-error">Please choose a timezone</span>
+		</md-autocomplete>
 		<div class="md-layout">
 			<Event
 				v-for="event in filterEvents()"
@@ -22,7 +43,7 @@
 	<SidePanel
 		:event="activeEvent"
 		:show-event="showEvent"
-		:tz="data.tz"
+		:user-timezone="userTimezone"
 	/>
 </div>
 </template>
@@ -44,11 +65,7 @@ export default {
 			showCurrentEvents: true,
 			activeEvent: null,
 			showEvent: false,
-			showSeriesDialog: false,
-			showTrackDialog: false,
-			showEventDialog: false,
-			showEventSessionDialog: false,
-			createdEvent: null
+			userTimezone: ''
 		};
 	},
 	computed: {
@@ -65,19 +82,6 @@ export default {
 		};
 	},
 	mounted() {
-		// Event
-		// this.$root.$on('toggleCrudEvent', () => {
-		// 	this.showEventDialog = !this.showEventDialog;
-		// });
-		// EventSession
-		// this.$root.$on('toggleCrudEventSession', () => {
-		// 	this.showEventSessionDialog = !this.showEventSessionDialog;
-		// });
-		// this.$root.$on('addEventSession', event => {
-		// 	this.showEventSessionDialog = !this.showEventSessionDialog;
-		// 	this.createdEvent = event;
-		// });
-
 		this.$root.$on('toggleCurrentEvents', () => {
 			this.showCurrentEvents = !this.showCurrentEvents;
 		});
@@ -90,6 +94,18 @@ export default {
 				this.activeEvent = null;
 			}
 		});
+		// Set the initial timezone
+		let tz_name = 'Europe/Brussels';
+		let tz_desc = this.data.tz.tz_strings[tz_name];
+		this.userTimezone = {
+			'name':tz_name,
+			'desc': tz_desc,
+			'toLowerCase':()=>tz_desc.toLowerCase(),
+			// 'toString':()=>'(UTC' + moment.tz(tz_name).format('Z') + ') ' + tz_desc
+			'toString':()=>tz_desc
+
+		};
+
 	},
 	methods: {
 		filterEvents: function() {
@@ -99,7 +115,10 @@ export default {
 				});
 			else
 				return this.data.events;
-		}
+		},
+		tzDisplay: function(item) {
+			return '(UTC' + moment.tz(item.name).format('Z') + ') ' + item.desc;
+		},
 	}
 };
 </script>


### PR DESCRIPTION
Users can now set a local timezone and the sessions times are displayed in both local time and the users' time.